### PR TITLE
[CSRE-327] Fix github org name in CODEOWNERS files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Babylonpartners/consumer-web
+* @babylonhealth/consumer-web


### PR DESCRIPTION
Fix github org name in CODEOWNERS files

[_Created by Sourcegraph batch change `alex.elmekeev/fix-CODEOWNERS-github-org`._](https://sg.sre.bbln.dev/users/alex.elmekeev/batch-changes/fix-CODEOWNERS-github-org)